### PR TITLE
Improve TSP Solver

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             "video_dir", module_name=""), tail), outfile)
 
         # preview file
-        if args["Output Options"]["preview"]:
+        if args["Output Options"].get("preview", False):
             os.startfile(outfile)
 
     except Exception as e:

--- a/options.py
+++ b/options.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 import os
+from typing import Any
 
 from manim import config
 
@@ -8,7 +9,7 @@ config.verbosity = "ERROR"
 config.frame_rate = 30
 
 
-def parse_args() -> dict[dict, ...]:
+def parse_args() -> dict[dict[str, Any]]:
     parser = ArgumentParser(
         description="Transform an image or a polygon into a series of rotating circles")
 

--- a/paths.py
+++ b/paths.py
@@ -1,46 +1,17 @@
+from python_tsp.heuristics import solve_tsp_lin_kernighan
 import numpy as np
 
 from tqdm import trange
 import platform
 
-# adapted from https://github.com/diego-vicente/som-tsp
-def self_organising_maps(points: np.ndarray, iterations: int = 0, learning_rate: float = 0.8) -> np.ndarray:
-    # keep points only once
-    # and then the population size is 8 times the number of cities
+def self_organising_maps(points: np.ndarray) -> np.ndarray:
+    # use known solver
     points = np.unique(points)
-    n = len(points) * 8
+    distance_matrix = np.abs(points[:,None] - points[None,:])
 
-    # generate an adequate network of neurons
-    network = np.random.uniform(min(points.real), max(
-        points.real), n) + 1j * np.random.uniform(min(points.imag), max(points.imag), n)
+    optimal_solution, _ = solve_tsp_lin_kernighan(distance_matrix)
 
-    if iterations == 0:
-        iterations = min(100000, int(np.log(n) / -np.log(.9997)))
-
-    for _ in trange(iterations, desc="Optimising shape", ascii=True if platform.system() == "Windows" else None, leave=False):
-        # choose a random city
-        point = np.random.choice(points)
-        idx = abs(network - point).argmin()
-
-        # generate a filter that applies changes to the winner's gaussian
-        # compute the circular network distance to the center
-        deltas = np.absolute(idx - np.arange(len(network)))
-        distances = np.minimum(deltas, len(network) - deltas)
-        # impose an upper bound on the radix to prevent NaN and blocks
-        radix = max(n / 10, 1)
-        # compute Gaussian distribution around the given center
-        gaussian = np.exp(-(distances**2) / (2*radix**2))
-
-        # update the network's weights (closer to the city)
-        network += gaussian * learning_rate * (point - network)
-
-        # decay the variables
-        learning_rate *= 0.99997
-        n *= 0.9997
-
-    # find route from network
-    route = points[np.argsort(
-        [np.argmin(abs(network - point)) for point in points])]
+    route = points[optimal_solution]
     return route
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 manim<0.19 # unknown breaking change in v0.19
 numpy
 opencv-python>=4.1
+python-tsp
 svgpathtools
 tqdm

--- a/utils.py
+++ b/utils.py
@@ -48,7 +48,7 @@ def extract_edges(image: np.ndarray, shortest_path: Callable[[np.ndarray], np.nd
         edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
     contours = np.ndarray(len(contours_), dtype=object)
     for i, contour in enumerate(contours_):
-        contours[i] = contours_[i]
+        contours[i] = contour
     # only keep contours with 50 or more pixels
     contours = contours[np.vectorize(len)(contours) > 50]
     # convert contours into complex numbers


### PR DESCRIPTION
Use [Lin and Kernighan TSP Solver](https://github.com/fillipe-gsm/python-tsp/blob/master/docs/solvers.rst#lin-and-kernighan)  in the [tsp-solver](https://github.com/fillipe-gsm/python-tsp/tree/master) package to compute the shortest path around points. This creates more robust paths with fewer artefacts.